### PR TITLE
singular form msgstr used together with msgid plural

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,6 +205,11 @@ Catalog.prototype.toPOs = function toPOs () {
         refs.push(ref);
         return refs;
       }, []);
+      
+      // generate msgstr for msgid_plural properly
+      if (item.msgid_plural !== null) {
+        item.msgstr = ['', ''];
+      }
 
       po.items.push(item);
     });


### PR DESCRIPTION
For plural form this tool generates this:
`msgid "%d Comment"
msgid_plural "%d Comments"
msgstr ""`

poedit and probably other editor are going to throw an error because when we use the plural form we should use multiple `msgstr`

My change will generate this result:
`msgid "%d Comment"
msgid_plural "%d Comments"
msgstr[0] ""
msgstr[1] ""`
